### PR TITLE
removed the hardcoding of en0 and made it dynamic for Wi-Fi adapter

### DIFF
--- a/heapbytes-mac.zsh-theme
+++ b/heapbytes-mac.zsh-theme
@@ -6,9 +6,11 @@ PROMPT='
 
 RPROMPT='[%F{red}%?%f]'
 
+# https://apple.stackexchange.com/questions/226871/how-can-i-get-the-list-of-all-active-network-interfaces-programmatically/226880#226880
 get_ip_address() {
-  if [[ -n "$(networksetup -getinfo Wi-Fi | grep 'Subnet mask: ')" ]]; then
-    echo "%{$fg[green]%}$(ifconfig en0 | awk '/inet / {print $2}')%{$reset_color%}"
+  ipAddress="$(ipconfig getifaddr $(networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}'))"
+  if [[ -n ipAddress ]]; then
+    echo "%{$fg[green]%}$ipAddress"
   else
     echo "%{$fg[red]%}No IP%{$reset_color%}"
   fi


### PR DESCRIPTION
I encountered a bug on my Mac mini when running the heabytes-zsh theme for Mac (heapbytes-mac.zsh-theme) - details below:

Issue: Ip address was not listed by the theme
Root-cause: adapter was hardcoded to en0, whereas in my environment the Wi-Fi adapter was assigned to en1
Resolution: Changed to pick the adapter name dynamically for Wi-Fi and pull the ip address
Verified it to work fine on my Mac (limited testing done)

