### PR TITLE
Add support for eth0 interface (WSL2) in get_ip_address function

### DIFF
--- a/heapbytes.zsh-theme
+++ b/heapbytes.zsh-theme
@@ -7,10 +7,9 @@ PROMPT='
 RPROMPT='[%F{red}%?%f]'
 
 get_ip_address() {
-  if [[ -n "$(ifconfig tun0 2>/dev/null)" ]]; then
-    echo "%{$fg[green]%}$(ifconfig tun0 | awk '/inet / {print $2}')%{$reset_color%}"
-  elif [[ -n "$(ifconfig wlan0 2>/dev/null)" ]]; then
-    echo "%{$fg[green]%}$(ifconfig wlan0 | awk '/inet / {print $2}')%{$reset_color%}"
+  local ip=$(ip -4 addr | awk '/inet/ && $2 !~ /^127/ {print $2}' | cut -d/ -f1 | head -n1)
+  if [[ -n "$ip" ]]; then
+    echo "%{$fg[green]%}$ip%{$reset_color%}"
   else
     echo "%{$fg[red]%}No IP%{$reset_color%}"
   fi

--- a/heapbytes.zsh-theme
+++ b/heapbytes.zsh-theme
@@ -7,11 +7,14 @@ PROMPT='
 RPROMPT='[%F{red}%?%f]'
 
 get_ip_address() {
-  local ip=$(ip -4 addr | awk '/inet/ && $2 !~ /^127/ {print $2}' | cut -d/ -f1 | head -n1)
-  if [[ -n "$ip" ]]; then
-    echo "%{$fg[green]%}$ip%{$reset_color%}"
+  if [[ -n "$(ifconfig tun0 2>/dev/null)" ]]; then
+    echo "%{$fg[green]%}$(ifconfig tun0 | awk '/inet / {print $2}')%{$reset_color%}"
   else
-    echo "%{$fg[red]%}No IP%{$reset_color%}"
+    local ip=$(ip -4 addr | awk '/inet/ && $2 !~ /^127/ {print $2}' | cut -d/ -f1 | head -n1)
+    if [[ -n "$ip" ]]; then
+      echo "%{$fg[green]%}$ip%{$reset_color%}"
+    else
+      echo "%{$fg[red]%}No IP%{$reset_color%}"
+    fi
   fi
 }
-


### PR DESCRIPTION
Hi there! 😊

While using this theme in a WSL2 (Windows Subsystem for Linux) environment, I noticed that the local IP address was not being displayed correctly. After some investigation, I found that the get_ip_address function only checks for the tun0 and wlan0 interfaces, which does not cover the WSL2 scenario—where the active interface is usually eth0.

This PR introduces two improvements:

Adds a check for the eth0 interface.

Alternatively, includes a more generic version of the function that automatically retrieves the first valid IP from any interface except lo.

These changes make the theme more compatible with various environments (WSL, VMs, containers, etc.), improving the overall user experience.

If any changes are needed or you prefer a different approach, I’m happy to adjust! 😄

Closes #8